### PR TITLE
PR: feat(zod, api): integrate Zod validation & move route logic to controllers

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,8 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "zod": "^4.1.5"
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
@@ -2643,6 +2644,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "zod": "^4.1.5"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,14 +1,19 @@
+// src/controllers/auth.controller.ts
 import { Request, Response } from "express";
 import { prisma } from "../prisma.js";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
+import type { SignupInput, LoginInput } from "../validators/auth.schema.js";
 
 const JWT_SECRET = process.env.JWT_SECRET || "supersecret"; // put in .env later
 
 // Signup
 export const signup = async (req: Request, res: Response) => {
+  // validated payload (Option A)
+  const validated = res.locals.validated as SignupInput;  
+  
   try {
-    const { email, password, name } = req.body;
+    const { email, password, name } = validated;
 
     const existingUser = await prisma.user.findUnique({ where: { email } });
     if (existingUser) return res.status(400).json({ message: "User already exists" });
@@ -36,8 +41,10 @@ export const signup = async (req: Request, res: Response) => {
 
 // Login
 export const login = async (req: Request, res: Response) => {
+  const validated = res.locals.validated as LoginInput;  
+  
   try {
-    const { email, password } = req.body;
+    const { email, password } = validated;
 
     const user = await prisma.user.findUnique({ where: { email } });
     if (!user) return res.status(400).json({ message: "Invalid credentials" });

--- a/backend/src/controllers/exam.controller.ts
+++ b/backend/src/controllers/exam.controller.ts
@@ -1,0 +1,95 @@
+// src/controllers/exam.controller.ts
+import { Request, Response } from "express";
+import { prisma } from "../prisma.js";
+import type { CreateExam, UpdateExam } from "../validators/exam.schema.js";
+
+/* ---------------- GET all exams (protected) ---------------- */
+export const getAllExams = async (_req: Request, res: Response) => {
+  try {
+    const exams = await prisma.exam.findMany();
+    res.json(exams);
+  } catch (error) {
+    console.error("getAllExams:", error);
+    res.status(500).json({ error: "Failed to fetch exams" });
+  }
+};
+
+/* ---------------- GET exam by id (public) ---------------- */
+export const getExamById = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const exam = await prisma.exam.findUnique({
+      where: { id },
+      include: {
+        subjects: {
+          include: {
+            topics: {
+              include: {
+                questions: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!exam) return res.status(404).json({ error: "Exam not found" });
+
+    res.json(exam);
+  } catch (error) {
+    console.error("getExamById:", error);
+    res.status(500).json({ error: "Failed to fetch exam" });
+  }
+};
+
+/* ---------------- CREATE exam (protected) ---------------- */
+export const createExam = async (req: Request, res: Response) => {
+  // Option A: simple cast from res.locals.validated
+  const validated = res.locals.validated as CreateExam;
+
+  try {
+    const exam = await prisma.exam.create({
+      data: {
+        name: validated.name,
+        ...(validated.syllabus !== undefined ? { syllabus: validated.syllabus } : {}),
+      },
+    });
+    res.status(201).json(exam);
+  } catch (error) {
+    console.error("createExam:", error);
+    res.status(500).json({ error: "Failed to create exam" });
+  }
+};
+
+/* ---------------- UPDATE exam (protected) ---------------- */
+export const updateExam = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const validated = res.locals.validated as UpdateExam;
+
+  try {
+    const exam = await prisma.exam.update({
+      where: { id },
+      data: {
+        ...(validated.name !== undefined ? { name: validated.name } : {}),
+        ...(validated.syllabus !== undefined ? { syllabus: validated.syllabus } : {}),
+      },
+    });
+    res.status(200).json(exam);
+  } catch (error: any) {
+    console.error("updateExam:", error);
+    // Preserve previous behavior: return 500 for other errors
+    res.status(500).json({ error: "Failed to update exam" });
+  }
+};
+
+/* ---------------- DELETE exam (protected) ---------------- */
+export const deleteExam = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    await prisma.exam.delete({ where: { id } });
+    res.status(200).json({ message: "Exam deleted successfully" });
+  } catch (error) {
+    console.error("deleteExam:", error);
+    res.status(500).json({ error: "Failed to delete exam" });
+  }
+};

--- a/backend/src/controllers/question.controller.ts
+++ b/backend/src/controllers/question.controller.ts
@@ -1,27 +1,36 @@
 import { Request, Response } from "express";
 import { prisma } from "../prisma.js";
+import type { CreateQuestionInput } from "../validators/question.schema.js";
 
 /* ---------------- Create Question (Admin only) ---------------- */
 export const createQuestion = async (req: Request, res: Response) => {
-  try {
-    const { topicId } = req.params;
-    const { text, options } = req.body;
-    // options = [{ text: "A", isCorrect: false }, ...]
 
+  const { topicId } = req.params;
+
+  // validated payload (Option A)
+  const validated = res.locals.validated as CreateQuestionInput;
+  const { text, options } = validated;
+
+
+  try {
     const question = await prisma.question.create({
       data: {
         text,
         topicId,
         options: {
-          create: options,
+          create: options.map((opt) => ({
+            text: opt.text,
+            isCorrect: opt.isCorrect,
+          })),
         },
       },
       include: { options: true },
     });
 
     res.status(201).json(question);
-  } catch (err) {
-    res.status(500).json({ message: "Error creating question", error: err });
+  } catch (error) {
+    console.error("createQuestion:", error);
+    res.status(500).json({ message: "Error creating question", error });
   }
 };
 
@@ -34,13 +43,14 @@ export const getQuestionsByTopic = async (req: Request, res: Response) => {
       where: { topicId },
       include: {
         options: {
-          select: { id: true, text: true }, // hide isCorrect
+          select: { id: true, text: true }, // hide isCorrect for students
         },
       },
     });
 
     res.json(questions);
   } catch (err) {
+    console.error("getQuestionsByTopic:", err);
     res.status(500).json({ message: "Error fetching questions", error: err });
   }
 };
@@ -63,6 +73,7 @@ export const getQuestionById = async (req: Request, res: Response) => {
 
     res.json(question);
   } catch (err) {
+    console.error("getQuestionById:", err);
     res.status(500).json({ message: "Error fetching question", error: err });
   }
 };

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -1,0 +1,134 @@
+// src/controllers/user.controller.ts
+import { Request, Response } from "express";
+import { prisma } from "../prisma.js";
+import bcrypt from "bcrypt";
+
+import type {
+  RegisterUser,
+  UpdateUser,
+  PromoteUserRole,
+} from "../validators/user.schema.js";
+
+/* ---------------- Helpers ---------------- */
+const sanitizeUser = (user: any) => {
+  const { password, ...rest } = user;
+  return rest;
+};
+
+/* ---------------- GET all users (ADMIN only) ---------------- */
+export const getAllUsers = async (_req: Request, res: Response) => {
+  try {
+    const users = await prisma.user.findMany({
+      include: { exams: { include: { exam: true } } },
+    });
+    res.json(users.map(sanitizeUser));
+  } catch (error) {
+    console.error("getAllUsers:", error);
+    res.status(500).json({ error: "Failed to fetch users" });
+  }
+};
+
+/* ---------------- GET user by id ---------------- */
+export const getUserById = async (req: Request, res: Response) => {
+  const { id } = req.params;
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id },
+      include: { exams: { include: { exam: true } } },
+    });
+    if (!user) return res.status(404).json({ error: "User not found" });
+    res.json(sanitizeUser(user));
+  } catch (error) {
+    console.error("getUserById:", error);
+    res.status(500).json({ error: "Failed to fetch user" });
+  }
+};
+
+/* ---------------- CREATE user (registration) ---------------- */
+export const createUser = async (req: Request, res: Response) => {
+  // Option A: simple cast
+  const validated = res.locals.validated as RegisterUser;
+
+  try {
+    const hashedPassword = await bcrypt.hash(validated.password, 10);
+    const user = await prisma.user.create({
+      data: {
+        email: validated.email,
+        name: validated.name,
+        password: hashedPassword,
+        role: "STUDENT", // default
+      },
+    });
+    res.status(201).json(sanitizeUser(user));
+  } catch (error: any) {
+    console.error("createUser:", error);
+    if (error?.code === "P2002") {
+      return res.status(400).json({ error: "Email already exists" });
+    }
+    res.status(500).json({ error: "Failed to create user" });
+  }
+};
+
+/* ---------------- UPDATE user ---------------- */
+export const updateUser = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const validated = res.locals.validated as UpdateUser;
+
+  try {
+    const updateData: any = {};
+    if (validated.name !== undefined) updateData.name = validated.name;
+    if (validated.role !== undefined) updateData.role = validated.role;
+    if (validated.password) {
+      updateData.password = await bcrypt.hash(validated.password, 10);
+    }
+
+    const user = await prisma.user.update({
+      where: { id },
+      data: updateData,
+    });
+
+    res.json(sanitizeUser(user));
+  } catch (error: any) {
+    console.error("updateUser:", error);
+    if (error?.code === "P2025") {
+      return res.status(404).json({ error: "User not found" });
+    }
+    res.status(500).json({ error: "Failed to update user" });
+  }
+};
+
+/* ---------------- DELETE user ---------------- */
+export const deleteUser = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    await prisma.user.delete({ where: { id } });
+    res.json({ message: "User deleted successfully" });
+  } catch (error: any) {
+    console.error("deleteUser:", error);
+    if (error?.code === "P2025") {
+      return res.status(404).json({ error: "User not found" });
+    }
+    res.status(500).json({ error: "Failed to delete user" });
+  }
+};
+
+/* ---------------- PROMOTE user role (ADMIN only) ---------------- */
+export const promoteUserRole = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const validated = res.locals.validated as PromoteUserRole;
+
+  try {
+    const user = await prisma.user.update({
+      where: { id },
+      data: { role: validated.role },
+    });
+    res.json({ message: "Role updated", user: sanitizeUser(user) });
+  } catch (error: any) {
+    console.error("promoteUserRole:", error);
+    if (error?.code === "P2025") {
+      return res.status(404).json({ error: "User not found" });
+    }
+    res.status(500).json({ error: "Failed to update role" });
+  }
+};

--- a/backend/src/controllers/userExam.controller.ts
+++ b/backend/src/controllers/userExam.controller.ts
@@ -1,0 +1,92 @@
+// src/controllers/userExam.controller.ts
+import { Request, Response } from "express";
+import { prisma } from "../prisma.js";
+import type { RegisterUserExam, UpdateProgress } from "../validators/userExam.schema.js";
+import type { Prisma } from "@prisma/client";
+
+/* ---------------- GET all user-exam records ---------------- */
+export const getAllUserExams = async (_req: Request, res: Response) => {
+  try {
+    const records = await prisma.userExam.findMany({
+      include: {
+        user: true,
+        exam: true,
+      },
+    });
+    res.json(records);
+  } catch (error) {
+    console.error("getAllUserExams:", error);
+    res.status(500).json({ error: "Failed to fetch user exams" });
+  }
+};
+
+/* ---------------- GET specific user-exam record ---------------- */
+export const getUserExamById = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const record = await prisma.userExam.findUnique({
+      where: { id },
+      include: { user: true, exam: true },
+    });
+    if (!record) return res.status(404).json({ error: "Record not found" });
+    res.json(record);
+  } catch (error) {
+    console.error("getUserExamById:", error);
+    res.status(500).json({ error: "Failed to fetch record" });
+  }
+};
+
+/* ---------------- REGISTER a user for an exam ---------------- */
+export const registerUserExam = async (req: Request, res: Response) => {
+  const validated = res.locals.validated as RegisterUserExam;
+  const { userId, examId, progress } = validated as {
+    userId: string;
+    examId: string;
+    progress?: Prisma.InputJsonValue;
+  };
+
+  try {
+    const record = await prisma.userExam.create({
+      data: {
+        userId,
+        examId,
+        progress: progress || {},
+      },
+      include: { user: true, exam: true },
+    });
+    res.status(201).json(record);
+  } catch (error) {
+    console.error("registerUserExam:", error);
+    res.status(500).json({ error: "Failed to register user for exam" });
+  }
+};
+
+/* ---------------- UPDATE progress ---------------- */
+export const updateUserExamProgress = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const validated = res.locals.validated as UpdateProgress;
+  const { progress } = validated as { progress: Prisma.InputJsonValue };
+
+  try {
+    const updated = await prisma.userExam.update({
+      where: { id },
+      data: { progress },
+    });
+    res.json(updated);
+  } catch (error) {
+    console.error("updateUserExamProgress:", error);
+    res.status(500).json({ error: "Failed to update progress" });
+  }
+};
+
+/* ---------------- DELETE user-exam record (unregister user) ---------------- */
+export const deleteUserExam = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    await prisma.userExam.delete({ where: { id } });
+    res.json({ message: "User removed from exam successfully" });
+  } catch (error) {
+    console.error("deleteUserExam:", error);
+    res.status(500).json({ error: "Failed to delete record" });
+  }
+};

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,16 +1,37 @@
+// src/middleware/authMiddleware.ts
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
+import type { UserRole } from "@prisma/client";
 
 const JWT_SECRET = process.env.JWT_SECRET || "supersecret";
 
+type AuthPayload = {
+  userId: string;
+  role?: UserRole | string;
+  email?: string;
+};
+
 export const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
   const authHeader = req.headers.authorization;
-  if (!authHeader) return res.status(401).json({ message: "No token provided" });
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({ message: "No token provided" });
+  }
 
-  const token = authHeader.split(" ")[1];
+  const parts = authHeader.split(" ");
+  if (parts.length < 2) {
+    return res.status(401).json({ message: "Malformed authorization header" });
+  }
+
+  const token = parts[1];
+
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as { userId: string; role: string };
-    (req as any).user = decoded; // attach user info to request
+    const decoded = jwt.verify(token, JWT_SECRET) as AuthPayload;
+    // normalize to the shape we declared in src/types/express.d.ts
+    req.user = {
+      id: decoded.userId,
+      role: decoded.role,
+      email: decoded.email,
+    };
     next();
   } catch (err) {
     return res.status(401).json({ message: "Invalid token" });

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,0 +1,29 @@
+// src/middleware/validate.ts
+import { RequestHandler } from "express";
+import { z, ZodError } from "zod";
+
+export function validate<T extends z.ZodTypeAny>(
+  schema: T,
+  source: "body" | "query" | "params" | "headers" = "body"
+): RequestHandler<any, any, any, any, { validated: z.infer<T> }> {
+  return (req, res, next) => {
+    try {
+      const raw = (req as any)[source];
+      const parsed = schema.parse(raw);
+
+      // Attach validated payload for downstream handlers
+      res.locals.validated = parsed as z.infer<T>;
+      return next();
+    } catch (err: unknown) {
+      if (err instanceof ZodError) {
+        // Use the new tree format (recommended replacement for `flatten()`).
+        // The structure is nested and more suitable for complex objects.
+        const errorTree = z.treeifyError(err);
+        return res.status(400).json({ errors: errorTree });
+      }
+
+      // Pass non-Zod errors to the default error handler
+      return next(err);
+    }
+  };
+}

--- a/backend/src/routes/answer.routes.ts
+++ b/backend/src/routes/answer.routes.ts
@@ -1,7 +1,10 @@
-import express, { Request, Response } from "express";
-import { prisma } from "../prisma.js";
+// src/routes/answer.routes.ts
+import express from "express";
 import { authMiddleware } from "../middleware/authMiddleware.js";
 import { authorize } from "../middleware/authorize.js";
+import { validate } from "../middleware/validate.js";
+import { submitAnswerSchema } from "../validators/answer.schema.js";
+import * as answerController from "../controllers/answer.controller.js";
 
 const router = express.Router();
 
@@ -10,55 +13,15 @@ router.post(
   "/questions/:id/answers",
   authMiddleware,
   authorize("STUDENT"),
-  async (req: Request, res: Response) => {
-    const { id: questionId } = req.params;
-    const { optionId } = req.body;
-    const user = (req as any).user;
-
-    try {
-      const answer = await prisma.answer.create({
-        data: {
-          userId: user.id,
-          questionId,
-          optionId,
-        },
-      });
-
-      res.status(201).json(answer);
-    } catch (error) {
-      console.error(error);
-      res.status(500).json({ message: "Error submitting answer" });
-    }
-  }
+  validate(submitAnswerSchema, "body"),
+  answerController.submitAnswer
 );
 
 /* ---------------- Get Answers by User ---------------- */
 router.get(
   "/users/:id/answers",
   authMiddleware,
-  async (req: Request, res: Response) => {
-    const { id } = req.params;
-    const user = (req as any).user;
-
-    if (user.role !== "ADMIN" && user.id !== id) {
-      return res.status(403).json({ message: "Forbidden" });
-    }
-
-    try {
-      const answers = await prisma.answer.findMany({
-        where: { userId: id },
-        include: {
-          question: { select: { text: true } },
-          option: { select: { text: true } },
-        },
-      });
-
-      res.json(answers);
-    } catch (error) {
-      console.error(error);
-      res.status(500).json({ message: "Error fetching answers" });
-    }
-  }
+  answerController.getAnswersByUser
 );
 
 /* ---------------- Get Answers by Exam (Admin only) ---------------- */
@@ -66,29 +29,7 @@ router.get(
   "/exams/:id/answers",
   authMiddleware,
   authorize("ADMIN"),
-  async (req: Request, res: Response) => {
-    const { id } = req.params;
-
-    try {
-      const answers = await prisma.answer.findMany({
-        where: {
-          question: {
-            topic: { subject: { examId: id } },
-          },
-        },
-        include: {
-          user: { select: { id: true, email: true } },
-          question: { select: { text: true } },
-          option: { select: { text: true, isCorrect: true } },
-        },
-      });
-
-      res.json(answers);
-    } catch (error) {
-      console.error(error);
-      res.status(500).json({ message: "Error fetching exam answers" });
-    }
-  }
+  answerController.getAnswersByExam
 );
 
 export default router;

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,9 +1,13 @@
+// src/routes/auth.routes.ts
 import { Router } from "express";
 import { signup, login } from "../controllers/auth.controller.js";
+import { validate } from "../middleware/validate.js";
+import { signupSchema, loginSchema } from "../validators/auth.schema.js";
 
 const router = Router();
 
-router.post("/signup", signup);
-router.post("/login", login);
+router.post("/signup", validate(signupSchema, "body"), signup);
+router.post("/login", validate(loginSchema, "body"), login);
 
 export default router;
+

--- a/backend/src/routes/question.routes.ts
+++ b/backend/src/routes/question.routes.ts
@@ -1,7 +1,10 @@
-import express, { Request, Response } from "express";
-import { prisma } from "../prisma.js";
+// src/routes/question.routes.ts
+import express from "express";
 import { authMiddleware } from "../middleware/authMiddleware.js";
 import { authorize } from "../middleware/authorize.js";
+import { validate } from "../middleware/validate.js";
+import { createQuestionSchema } from "../validators/question.schema.js";
+import * as questionController from "../controllers/question.controller.js";
 
 const router = express.Router();
 
@@ -10,89 +13,22 @@ router.post(
   "/topics/:topicId/questions",
   authMiddleware,
   authorize("ADMIN"),
-  async (req: Request, res: Response) => {
-    const { topicId } = req.params;
-    const { text, options } = req.body;
-
-    try {
-      const question = await prisma.question.create({
-        data: {
-          text,
-          topicId,
-          options: {
-            create: options.map((opt: { text: string; isCorrect: boolean }) => ({
-              text: opt.text,
-              isCorrect: opt.isCorrect,
-            })),
-          },
-        },
-        include: { options: true },
-      });
-
-      res.status(201).json(question);
-    } catch (error) {
-      console.error(error);
-      res.status(500).json({ message: "Error creating question" });
-    }
-  }
+  validate(createQuestionSchema, "body"),
+  questionController.createQuestion
 );
 
 /* ---------------- Get Questions by Topic (Students/Admin) ---------------- */
 router.get(
   "/topics/:topicId/questions",
   authMiddleware,
-  async (req: Request, res: Response) => {
-    const { topicId } = req.params;
-
-    try {
-      const questions = await prisma.question.findMany({
-        where: { topicId },
-        include: {
-          options: {
-            select: {
-              id: true,
-              text: true,
-              // 🚨 hide isCorrect so students can’t see
-            },
-          },
-        },
-      });
-
-      res.json(questions);
-    } catch (error) {
-      console.error(error);
-      res.status(500).json({ message: "Error fetching questions" });
-    }
-  }
+  questionController.getQuestionsByTopic
 );
 
 /* ---------------- Get Single Question ---------------- */
 router.get(
   "/questions/:id",
   authMiddleware,
-  async (req: Request, res: Response) => {
-    const { id } = req.params;
-
-    try {
-      const question = await prisma.question.findUnique({
-        where: { id },
-        include: {
-          options: {
-            select: { id: true, text: true }, // hide isCorrect
-          },
-        },
-      });
-
-      if (!question) {
-        return res.status(404).json({ message: "Question not found" });
-      }
-
-      res.json(question);
-    } catch (error) {
-      console.error(error);
-      res.status(500).json({ message: "Error fetching question" });
-    }
-  }
+  questionController.getQuestionById
 );
 
 export default router;

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -1,156 +1,42 @@
 // src/routes/user.routes.ts
-import express, { RequestHandler } from "express";
-import { prisma } from "../prisma.js";
-import { UserRole } from "@prisma/client";
-import { ParamsDictionary } from "express-serve-static-core";
-import bcrypt from "bcrypt";
+import express from "express";
 import { authMiddleware } from "../middleware/authMiddleware.js";
 import { authorize } from "../middleware/authorize.js";
 
+import { validate } from "../middleware/validate.js";
+import {
+  registerUserSchema,
+  updateUserSchema,
+  promoteUserRoleSchema,
+} from "../validators/user.schema.js";
+
+import * as userController from "../controllers/user.controller.js";
+
 const router = express.Router();
 
-/* ---------------- Types ---------------- */
-interface UserBody {
-  email: string;
-  name: string;
-  role?: UserRole;
-  password: string;
-}
-
-interface UserParams extends ParamsDictionary {
-  id: string;
-}
-
-/* ---------------- Helpers ---------------- */
-// Exclude password before sending user in response
-const sanitizeUser = (user: any) => {
-  const { password, ...rest } = user;
-  return rest;
-};
-
-/* ---------------- GET all users (with exams) ---------------- */
-const getAllUsers: RequestHandler = async (_req, res) => {
-  try {
-    const users = await prisma.user.findMany({
-      include: {
-        exams: { include: { exam: true } },
-      },
-    });
-
-    res.json(users.map(sanitizeUser));
-  } catch (error) {
-    res.status(500).json({ error: "Failed to fetch users" });
-  }
-};
-router.get("/", getAllUsers);
+/* ---------------- GET all users (ADMIN only) ---------------- */
+router.get("/", authMiddleware, authorize("ADMIN"), userController.getAllUsers);
 
 /* ---------------- GET user by id ---------------- */
-const getUserById: RequestHandler<UserParams> = async (req, res) => {
-  const { id } = req.params;
-  try {
-    const user = await prisma.user.findUnique({
-      where: { id },
-      include: {
-        exams: { include: { exam: true } },
-      },
-    });
+// publicly accessible in original code — keep same behavior
+router.get("/:id", userController.getUserById);
 
-    if (!user) {
-      res.status(404).json({ error: "User not found" });
-      return;
-    }
-
-    res.json(sanitizeUser(user));
-  } catch (error) {
-    res.status(500).json({ error: "Failed to fetch user" });
-  }
-};
-router.get("/:id", getUserById);
-
-/* ---------------- CREATE user ---------------- */
-const createUser: RequestHandler<{}, any, UserBody> = async (req, res) => {
-  const { email, name, role, password } = req.body;
-
-  try {
-    const hashedPassword = await bcrypt.hash(password, 10);
-
-    const user = await prisma.user.create({
-      data: { email, name, role, password: hashedPassword },
-    });
-
-    res.json(sanitizeUser(user));
-  } catch (error: any) {
-    if (error.code === "P2002") {
-      res.status(400).json({ error: "Email already exists" });
-      return;
-    }
-    res.status(500).json({ error: "Failed to create user" });
-  }
-};
-router.post("/", createUser);
+/* ---------------- CREATE user (registration) ---------------- */
+router.post("/", validate(registerUserSchema, "body"), userController.createUser);
 
 /* ---------------- UPDATE user ---------------- */
-const updateUser: RequestHandler<UserParams, any, Partial<UserBody>> = async (
-  req,
-  res
-) => {
-  const { id } = req.params;
-  const { name, role, password } = req.body;
-
-  try {
-    const updateData: any = { name, role };
-
-    if (password) {
-      updateData.password = await bcrypt.hash(password, 10);
-    }
-
-    const user = await prisma.user.update({
-      where: { id },
-      data: updateData,
-    });
-
-    res.json(sanitizeUser(user));
-  } catch (error) {
-    res.status(500).json({ error: "Failed to update user" });
-  }
-};
-router.put("/:id", updateUser);
+router.put("/:id", validate(updateUserSchema, "body"), userController.updateUser);
 
 /* ---------------- DELETE user ---------------- */
-const deleteUser: RequestHandler<UserParams> = async (req, res) => {
-  const { id } = req.params;
-  try {
-    await prisma.user.delete({ where: { id } });
-    res.json({ message: "User deleted successfully" });
-  } catch (error) {
-    res.status(500).json({ error: "Failed to delete user" });
-  }
-};
-router.delete("/:id", deleteUser);
+router.delete("/:id", userController.deleteUser);
 
 /* ---------------- PROMOTE user role (ADMIN only) ---------------- */
-const promoteUserRole: RequestHandler<UserParams, any, { role: UserRole }> =
-  async (req, res) => {
-    const { id } = req.params;
-    const { role } = req.body;
-
-    try {
-      const user = await prisma.user.update({
-        where: { id },
-        data: { role },
-      });
-
-      res.json({ message: "Role updated", user: sanitizeUser(user) });
-    } catch (error) {
-      res.status(500).json({ error: "Failed to update role" });
-    }
-  };
-
 router.patch(
   "/:id/role",
   authMiddleware,
   authorize("ADMIN"),
-  promoteUserRole
+  validate(promoteUserRoleSchema, "body"),
+  userController.promoteUserRole
 );
 
 export default router;

--- a/backend/src/scripts/test-schemas.ts
+++ b/backend/src/scripts/test-schemas.ts
@@ -1,0 +1,19 @@
+// src/scripts/test-schemas.ts
+import { createExamSchema } from "../validators/exam.schema.js";
+import { submitAnswerSchema } from "../validators/answer.schema.js";
+
+const goodExam = {
+  name: "Sample Exam",
+  syllabus: { subjects: [{ name: "Math", topics: ["Algebra"] }] },
+};
+
+const badExam = { name: "" };
+
+console.log("GOOD exam:", createExamSchema.safeParse(goodExam)); // success: true
+console.log("BAD exam:", createExamSchema.safeParse(badExam));  // success: false
+
+const goodAnswer = { optionId: "550e8400-e29b-41d4-a716-446655440000" };
+const badAnswer = { optionId: "not-a-uuid" };
+
+console.log("GOOD answer:", submitAnswerSchema.safeParse(goodAnswer)); // success: true
+console.log("BAD answer:", submitAnswerSchema.safeParse(badAnswer));   // success: false

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -35,3 +35,11 @@ app.use("/api", answerRoutes);                // /questions/:id/answers, /users/
 app.listen(PORT, () => {
   console.log(`✅ Server running on http://localhost:${PORT}`);
 });
+
+// TODO: Centralized error handling
+// - Add a global errorHandler middleware (src/middleware/errorHandler.ts)
+// - Wrap async routes with asyncHandler to avoid try/catch repetition
+// - Map Prisma errors (P2002 unique constraint, P2025 not found, etc.) to user-friendly messages
+// - Use ApiError class or http-errors package for consistent error shapes
+// - This will make the backend look production-ready
+

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,27 @@
+// src/types/express.d.ts
+import "express-serve-static-core";
+import type { UserRole } from "@prisma/client";
+
+declare module "express-serve-static-core" {
+  // typed user attached by your authMiddleware
+  interface Request {
+    user?: {
+      id: string;
+      email?: string;
+      role?: UserRole | string;
+    };
+  }
+
+  // existing Locals augmentation (keep as you had it)
+  interface Locals {
+    /**
+     * validated is intentionally unknown here — controllers must cast to the
+     * specific z.infer<> type they expect. This keeps type-safety while avoiding
+     * complicated middleware generics (Option A approach).
+     */
+    validated?: unknown;
+  }
+}
+
+export {};
+

--- a/backend/src/validators/answer.schema.ts
+++ b/backend/src/validators/answer.schema.ts
@@ -1,0 +1,12 @@
+// src/validators/answer.schema.ts
+import { z } from "zod";
+
+/**
+ * We validate only the optionId here. userId will come from authenticated req.user.
+ * Using strict UUID validation (z.uuid()) to match Prisma's UUID ids.
+ */
+export const submitAnswerSchema = z.object({
+  optionId: z.uuid(),
+});
+
+export type SubmitAnswer = z.infer<typeof submitAnswerSchema>;

--- a/backend/src/validators/auth.schema.ts
+++ b/backend/src/validators/auth.schema.ts
@@ -1,0 +1,15 @@
+// src/validators/auth.schema.ts
+import { z } from "zod";
+
+export const signupSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 chars"),
+  email: z.email("Invalid email"),
+  password: z.string().min(6, "Password must be at least 6 chars"),
+});
+export type SignupInput = z.infer<typeof signupSchema>;
+
+export const loginSchema = z.object({
+  email: z.email("Invalid email"),
+  password: z.string().min(6, "Password must be at least 6 chars"),
+});
+export type LoginInput = z.infer<typeof loginSchema>;

--- a/backend/src/validators/exam.schema.ts
+++ b/backend/src/validators/exam.schema.ts
@@ -1,0 +1,14 @@
+// src/validators/exam.schema.ts
+import { z } from "zod";
+import { syllabusSchema } from "./syllabus.schema.js";
+
+export const createExamSchema = z.object({
+  name: z.string().min(1, "Exam name is required"),
+  // syllabus is optional — reuse your existing syllabus schema
+  syllabus: syllabusSchema.optional(),
+});
+
+export const updateExamSchema = createExamSchema.partial();
+
+export type CreateExam = z.infer<typeof createExamSchema>;
+export type UpdateExam = z.infer<typeof updateExamSchema>;

--- a/backend/src/validators/question.schema.ts
+++ b/backend/src/validators/question.schema.ts
@@ -1,0 +1,13 @@
+// src/validators/question.schema.ts
+import { z } from "zod";
+
+export const optionSchema = z.object({
+  text: z.string(),
+  isCorrect: z.boolean(),
+});
+
+export const createQuestionSchema = z.object({
+  text: z.string().min(1),
+  options: z.array(optionSchema).min(2, "At least 2 options required"),
+});
+export type CreateQuestionInput = z.infer<typeof createQuestionSchema>;

--- a/backend/src/validators/syllabus.schema.ts
+++ b/backend/src/validators/syllabus.schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const syllabusSchema = z.object({
+  subjects: z.array(
+    z.object({
+      name: z.string(),
+      topics: z.array(z.string()),
+    })
+  ),
+});
+
+// ✅ Infer TypeScript type from Zod schema
+export type Syllabus = z.infer<typeof syllabusSchema>;

--- a/backend/src/validators/user.schema.ts
+++ b/backend/src/validators/user.schema.ts
@@ -1,0 +1,31 @@
+// src/validators/user.schema.ts
+import { z } from "zod";
+
+/**
+ * Define allowed roles explicitly with z.enum.
+ * Keep this list in sync with your Prisma `UserRole` enum:
+ * enum UserRole { ADMIN STUDENT }
+ */
+export const userRoleSchema = z.enum(["ADMIN", "STUDENT"] as const);
+
+export const registerUserSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 chars"),
+  email: z.email("Invalid email"),
+  password: z.string().min(6, "Password must be at least 6 chars"),
+});
+
+export const updateUserSchema = z.object({
+  name: z.string().min(2).optional(),
+  role: userRoleSchema.optional(),
+  password: z.string().min(6).optional(),
+});
+
+export const promoteUserRoleSchema = z.object({
+  role: userRoleSchema,
+});
+
+export type RegisterUser = z.infer<typeof registerUserSchema>;
+export type UpdateUser = z.infer<typeof updateUserSchema>;
+export type PromoteUserRole = z.infer<typeof promoteUserRoleSchema>;
+export type UserRole = z.infer<typeof userRoleSchema>;
+

--- a/backend/src/validators/userExam.schema.ts
+++ b/backend/src/validators/userExam.schema.ts
@@ -1,0 +1,23 @@
+// src/validators/userExam.schema.ts
+import { z } from "zod";
+
+/**
+ * progress is stored as Prisma.Json. We accept a loose object map here:
+ * keys are strings, values are unknown (safer than `any`).
+ *
+ * Use z.unknown() for values to avoid letting functions slip through.
+ * Use z.any() if you want maximum permissiveness.
+ */
+export const registerUserExamSchema = z.object({
+  userId: z.uuid(),
+  examId: z.uuid(),
+  // keep progress loose: object (optional). If you later define structure, tighten this.
+  progress: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const updateProgressSchema = z.object({
+  progress: z.record(z.string(), z.unknown()),
+});
+
+export type RegisterUserExam = z.infer<typeof registerUserExamSchema>;
+export type UpdateProgress = z.infer<typeof updateProgressSchema>;


### PR DESCRIPTION
## Summary

This PR integrates Zod validation across the API and moves business logic out of route files into controllers for clearer separation of concerns. It implements the Option A pattern (simple casts of `res.locals.validated` to `z.infer<>` types inside controllers), adds two new validators, and wires the existing `validate()` middleware into all input-bearing routes.

---

## What this PR does

* Adds Zod validators:

  * `src/validators/exam.schema.ts`
  * `src/validators/answer.schema.ts`
* Wires `validate()` middleware across routes:

  * `auth`, `user`, `exam`, `question`, `answer`, `userExam`
* Moves DB/business logic from routes into controllers:

  * New controllers: `src/controllers/exam.controller.ts`, `src/controllers/user.controller.ts`, `src/controllers/userExam.controller.ts`
  * Updated controllers: `auth`, `question`, `answer` to use validated payloads
* Updates types:

  * `src/types/express.d.ts` → `res.locals.validated?: unknown` (explicit casts in controllers)
* Adds test/dev scripts to help manual testing:

  * `src/scripts/create-admin.ts`
  * `src/scripts/test-exam-creation.ts`
  * `src/scripts/test-schemas.ts`
* Small cleanups:

  * Removed unused imports, ensured POST endpoints return `201` on creates, consistent error logging

---

## Files (high-level)

**Added**

* `src/validators/exam.schema.ts`
* `src/validators/answer.schema.ts`
* `src/controllers/exam.controller.ts`
* `src/controllers/user.controller.ts`
* `src/controllers/userExam.controller.ts`
* `src/scripts/create-admin.ts`
* `src/scripts/test-exam-creation.ts`
* `src/scripts/test-schemas.ts`

**Updated**

* `src/routes/auth.routes.ts`
* `src/routes/user.routes.ts`
* `src/routes/exam.routes.ts`
* `src/routes/question.routes.ts`
* `src/routes/answer.routes.ts`
* `src/routes/userExam.routes.ts`
* `src/controllers/auth.controller.ts`
* `src/controllers/question.controller.ts`
* `src/controllers/answer.controller.ts`
* `src/controllers/answer.controller.ts`
* `src/types/express.d.ts`
* `src/routes/*` now call controllers and apply `validate()` where appropriate

(See full diff in PR for exact file list/changes.)

---

## How to test (quick smoke)

1. Type-check:

```bash
npx tsc --noEmit
```

2. Start dev server:

```bash
npm run dev
```

3. Create an admin user (seeds/upserts an ADMIN) and get a token:

```bash
npx tsx src/scripts/create-admin.ts
# then login via POST /auth/login with the printed credentials to obtain JWT
```

4. Create an exam (ADMIN):

```bash
npx tsx src/scripts/test-exam-creation.ts
# or: curl -X POST http://localhost:5000/api/exams -H "Authorization: Bearer <ADMIN_JWT>" -d '{ ... }'
```

5. Test other flows:

* Signup/login (`/auth/signup`, `/auth/login`) — `validate()` is applied.
* Create user (`POST /api/users`), update user (`PUT /api/users/:id`), promote user (`PATCH /api/users/:id/role`).
* Create question (`POST /api/topics/:topicId/questions`) — admin only.
* Submit answer (`POST /api/questions/:questionId/answers`) — student only.
* Register user for exam (`POST /api/user-exams`) and update progress (`PUT /api/user-exams/:id`).

6. Optional: run schema tests:

```bash
npx tsx src/scripts/test-schemas.ts
```

---

## Notes for reviewers

* Zod v4-style helpers are used (`z.uuid()`, top-level `z.*`) — avoid deprecated chained helpers (e.g., `z.string().uuid()`).
* The pattern chosen (Option A) keeps middleware simple and requires controllers to cast `res.locals.validated` explicitly:

  ```ts
  const validated = res.locals.validated as SomeSchemaType;
  ```

  This keeps the TypeScript surface area small and is easier to review and reason about.
* No DB schema changes were made in this PR (no migrations). The `syllabus` field remains a JSON column — creating an exam with `syllabus` does not create `Subject`/`Topic` relational rows (we kept this behavior intentionally for now).
* Response shapes/status codes preserved where possible to minimize breaking changes.

---

## Testing checklist (for merge)

* [ ] `npx tsc --noEmit` passes
* [ ] `npm run dev` runs without runtime crashes
* [ ] Admin creation script works and admin can log in
* [ ] Create/update flows for `exam`, `user`, `question`, `answer`, `userExam` succeed with valid payloads
* [ ] Invalid payloads return `400` with Zod error details (via `validate()` middleware)

---

## Follow-ups (future work / not part of this PR)

* Optionally strengthen `validate()` to carry typed generics across middleware so controllers can avoid casts (migrate to Option B).
* Consider adding a global error handler and async wrapper to remove repetitive try/catch blocks.
* Decide whether `syllabus` JSON should sync to relational `Subject`/`Topic` rows (nested create vs. sync job) and implement migrations/upserts if needed.

---
