### PR TITLE
migrations(db): minimal schema changes — add QuestionVersion + related fields

### DIFF
--- a/backend/prisma/migrations/20250910110609_useful_changes_to_schema/migration.sql
+++ b/backend/prisma/migrations/20250910110609_useful_changes_to_schema/migration.sql
@@ -1,0 +1,236 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Answer` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Exam` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Option` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Question` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Subject` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Topic` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `User` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `UserExam` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."Answer" DROP CONSTRAINT "Answer_optionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Answer" DROP CONSTRAINT "Answer_questionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Answer" DROP CONSTRAINT "Answer_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Option" DROP CONSTRAINT "Option_questionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Question" DROP CONSTRAINT "Question_topicId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Subject" DROP CONSTRAINT "Subject_examId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Topic" DROP CONSTRAINT "Topic_subjectId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."UserExam" DROP CONSTRAINT "UserExam_examId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."UserExam" DROP CONSTRAINT "UserExam_userId_fkey";
+
+-- DropTable
+DROP TABLE "public"."Answer";
+
+-- DropTable
+DROP TABLE "public"."Exam";
+
+-- DropTable
+DROP TABLE "public"."Option";
+
+-- DropTable
+DROP TABLE "public"."Question";
+
+-- DropTable
+DROP TABLE "public"."Subject";
+
+-- DropTable
+DROP TABLE "public"."Topic";
+
+-- DropTable
+DROP TABLE "public"."User";
+
+-- DropTable
+DROP TABLE "public"."UserExam";
+
+-- CreateTable
+CREATE TABLE "public"."users" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "role" "public"."UserRole" NOT NULL DEFAULT 'STUDENT',
+    "password" TEXT NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."exams" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "syllabus" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "exams_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."user_exams" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "examId" TEXT NOT NULL,
+    "progress" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finishedAt" TIMESTAMP(3),
+    "score" DOUBLE PRECISION,
+    "attemptNumber" INTEGER NOT NULL DEFAULT 1,
+    "status" TEXT NOT NULL DEFAULT 'IN_PROGRESS',
+
+    CONSTRAINT "user_exams_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."subjects" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "examId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "subjects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."topics" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "subjectId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "topics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."questions" (
+    "id" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "topicId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "questions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."options" (
+    "id" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "isCorrect" BOOLEAN NOT NULL DEFAULT false,
+    "questionId" TEXT NOT NULL,
+
+    CONSTRAINT "options_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."answers" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "questionId" TEXT,
+    "optionId" TEXT,
+    "questionVersionId" TEXT,
+    "isCorrect" BOOLEAN,
+    "timeTakenMs" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "answers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."question_versions" (
+    "id" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "text" TEXT NOT NULL,
+    "options" JSONB NOT NULL,
+    "explanation" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "question_versions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."tags" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tags_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."question_tag" (
+    "questionId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+
+    CONSTRAINT "question_tag_pkey" PRIMARY KEY ("questionId","tagId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "public"."users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "question_versions_questionId_versionNumber_key" ON "public"."question_versions"("questionId", "versionNumber");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tags_name_key" ON "public"."tags"("name");
+
+-- AddForeignKey
+ALTER TABLE "public"."user_exams" ADD CONSTRAINT "user_exams_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."user_exams" ADD CONSTRAINT "user_exams_examId_fkey" FOREIGN KEY ("examId") REFERENCES "public"."exams"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."subjects" ADD CONSTRAINT "subjects_examId_fkey" FOREIGN KEY ("examId") REFERENCES "public"."exams"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."topics" ADD CONSTRAINT "topics_subjectId_fkey" FOREIGN KEY ("subjectId") REFERENCES "public"."subjects"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."questions" ADD CONSTRAINT "questions_topicId_fkey" FOREIGN KEY ("topicId") REFERENCES "public"."topics"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."options" ADD CONSTRAINT "options_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "public"."questions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."answers" ADD CONSTRAINT "answers_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."answers" ADD CONSTRAINT "answers_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "public"."questions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."answers" ADD CONSTRAINT "answers_optionId_fkey" FOREIGN KEY ("optionId") REFERENCES "public"."options"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."answers" ADD CONSTRAINT "answers_questionVersionId_fkey" FOREIGN KEY ("questionVersionId") REFERENCES "public"."question_versions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."question_versions" ADD CONSTRAINT "question_versions_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "public"."questions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."question_tag" ADD CONSTRAINT "question_tag_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "public"."questions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."question_tag" ADD CONSTRAINT "question_tag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "public"."tags"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250910115416_answer_model_cleanup_and_remove_answers_backrelations/migration.sql
+++ b/backend/prisma/migrations/20250910115416_answer_model_cleanup_and_remove_answers_backrelations/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `optionId` on the `answers` table. All the data in the column will be lost.
+  - You are about to drop the column `questionId` on the `answers` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."answers" DROP CONSTRAINT "answers_optionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."answers" DROP CONSTRAINT "answers_questionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."answers" DROP CONSTRAINT "answers_questionVersionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."answers" DROP CONSTRAINT "answers_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."answers" DROP COLUMN "optionId",
+DROP COLUMN "questionId",
+ADD COLUMN     "selectedOptionId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "answers_userId_idx" ON "public"."answers"("userId");
+
+-- CreateIndex
+CREATE INDEX "answers_questionVersionId_idx" ON "public"."answers"("questionVersionId");
+
+-- AddForeignKey
+ALTER TABLE "public"."answers" ADD CONSTRAINT "answers_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."answers" ADD CONSTRAINT "answers_questionVersionId_fkey" FOREIGN KEY ("questionVersionId") REFERENCES "public"."question_versions"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250910131958_add_user_exam_status_and_constraints/migration.sql
+++ b/backend/prisma/migrations/20250910131958_add_user_exam_status_and_constraints/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `score` on the `user_exams` table. The data in that column could be lost. The data in that column will be cast from `DoublePrecision` to `Decimal(7,3)`.
+  - A unique constraint covering the columns `[userId,examId,attemptNumber]` on the table `user_exams` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateEnum
+CREATE TYPE "public"."ExamStatus" AS ENUM ('IN_PROGRESS', 'COMPLETED', 'ABORTED');
+
+-- AlterTable
+ALTER TABLE "public"."user_exams" ALTER COLUMN "progress" SET DEFAULT '{}',
+ALTER COLUMN "score" SET DATA TYPE DECIMAL(7,3);
+
+-- CreateIndex
+CREATE INDEX "user_exams_userId_idx" ON "public"."user_exams"("userId");
+
+-- CreateIndex
+CREATE INDEX "user_exams_examId_idx" ON "public"."user_exams"("examId");
+
+-- CreateIndex
+CREATE INDEX "user_exams_userId_examId_status_idx" ON "public"."user_exams"("userId", "examId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_exams_userId_examId_attemptNumber_key" ON "public"."user_exams"("userId", "examId", "attemptNumber");

--- a/backend/prisma/migrations/20250910134124_add_ondelete_cascade_to_questiontag_tag/migration.sql
+++ b/backend/prisma/migrations/20250910134124_add_ondelete_cascade_to_questiontag_tag/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "public"."question_tag" DROP CONSTRAINT "question_tag_questionId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."question_tag" DROP CONSTRAINT "question_tag_tagId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "public"."question_tag" ADD CONSTRAINT "question_tag_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "public"."questions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."question_tag" ADD CONSTRAINT "question_tag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "public"."tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250910174236_changes_user_table/migration.sql
+++ b/backend/prisma/migrations/20250910174236_changes_user_table/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - The `status` column on the `user_exams` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."user_exams" DROP CONSTRAINT "user_exams_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."user_exams" DROP COLUMN "status",
+ADD COLUMN     "status" "public"."ExamStatus" NOT NULL DEFAULT 'IN_PROGRESS';
+
+-- AlterTable
+ALTER TABLE "public"."users" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isAnonymized" BOOLEAN DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "user_exams_userId_examId_status_idx" ON "public"."user_exams"("userId", "examId", "status");
+
+-- AddForeignKey
+ALTER TABLE "public"."user_exams" ADD CONSTRAINT "user_exams_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,35 +7,67 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/**
+ * NOTE:
+ * - We keep model names in PascalCase for readability.
+ * - @@map ensures underlying DB tables are snake_case (questions, options, etc.)
+ * - Add migrations incrementally.
+ */
+
 model User {
   id        String     @id @default(uuid())
-  email     String     @unique 
+  email     String     @unique
   name      String?
   createdAt DateTime   @default(now())
   role      UserRole   @default(STUDENT)
   password  String
   exams     UserExam[]
   answers   Answer[]
+
+  isAnonymized Boolean? @default(false)
+  deletedAt DateTime?  
+
+  @@map("users")
 }
 
 model Exam {
   id        String     @id @default(uuid())
-  name      String     
+  name      String
   syllabus  Json?
   createdAt DateTime   @default(now())
   subjects  Subject[]
   users     UserExam[]
+
+  @@map("exams")
 }
 
 model UserExam {
-  id        String   @id @default(uuid())
-  userId    String
-  examId    String
-  progress  Json
-  createdAt DateTime @default(now())
-  exam      Exam     @relation(fields: [examId], references: [id])
-  user      User     @relation(fields: [userId], references: [id])
+  id            String        @id @default(uuid()) 
+  userId        String    
+  examId        String    
+  progress      Json?         @default("{}")
+  createdAt     DateTime      @default(now())
+  startedAt     DateTime      @default(now())
+  finishedAt    DateTime?
+  score         Decimal?      @db.Decimal(7,3)
+  attemptNumber Int           @default(1)
+  status        ExamStatus    @default(IN_PROGRESS)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  exam Exam @relation(fields: [examId], references: [id])
+
+  @@map("user_exams")
+  @@unique([userId, examId, attemptNumber])
+  @@index([userId])
+  @@index([examId])
+  @@index([userId, examId, status])
 }
+
+enum ExamStatus {
+  IN_PROGRESS
+  COMPLETED
+  ABORTED
+} 
 
 model Subject {
   id     String  @id @default(uuid())
@@ -43,14 +75,24 @@ model Subject {
   examId String
   exam   Exam    @relation(fields: [examId], references: [id])
   topics Topic[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("subjects")
 }
 
 model Topic {
   id        String     @id @default(uuid())
   name      String
   subjectId String
-  questions Question[]
   subject   Subject    @relation(fields: [subjectId], references: [id])
+  questions Question[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("topics")
 }
 
 model Question {
@@ -59,7 +101,12 @@ model Question {
   topicId   String
   topic     Topic    @relation(fields: [topicId], references: [id])
   options   Option[]
-  answers   Answer[]
+  createdAt DateTime @default(now())
+
+  questionVersions QuestionVersion[] // back-relation for QuestionVersion.question
+  questionTags     QuestionTag[] // back-relation for QuestionTag.question
+
+  @@map("questions")
 }
 
 model Option {
@@ -68,18 +115,65 @@ model Option {
   isCorrect  Boolean  @default(false)
   questionId String
   question   Question @relation(fields: [questionId], references: [id])
-  answers    Answer[]
+
+  @@map("options")
 }
 
 model Answer {
-  id         String   @id @default(uuid())
-  userId     String
-  user       User     @relation(fields: [userId], references: [id])
+  id                String           @id @default(uuid())
+  userId            String
+  user              User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  questionVersionId String?          // nullable if we allow answers without a snapshot
+  questionVersion   QuestionVersion? @relation(fields: [questionVersionId], references: [id], onDelete: Cascade)
+  selectedOptionId  String?          // snapshot: { id, text }
+  isCorrect         Boolean?
+  timeTakenMs       Int?
+  createdAt         DateTime         @default(now())
+
+  @@index([userId])
+  @@index([questionVersionId])
+  @@map("answers")
+}
+
+/**
+ * NEW model: QuestionVersion
+ * - snapshots question text and options (as Json)
+ * - unique per (questionId, versionNumber)
+ */
+
+model QuestionVersion {
+  id            String   @id @default(uuid())
+  questionId    String
+  question      Question @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  versionNumber Int
+  text          String // snapshot of question text (keeps naming consistent with Question.text)
+  options       Json // array of options snapshot: [{id, text, isCorrect?}]
+  explanation   String?
+  metadata      Json?
+  createdAt     DateTime @default(now())
+  Answer        Answer[]
+
+  @@unique([questionId, versionNumber])
+  @@map("question_versions")
+}
+
+model Tag {
+  id           String        @id @default(uuid())
+  name         String        @unique
+  createdAt    DateTime      @default(now())
+  questionTags QuestionTag[]
+
+  @@map("tags")
+}
+
+model QuestionTag {
   questionId String
-  question   Question @relation(fields: [questionId], references: [id])
-  optionId   String
-  option     Option   @relation(fields: [optionId], references: [id])
-  createdAt  DateTime @default(now())
+  tagId      String
+  question   Question @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  tag        Tag      @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([questionId, tagId])
+  @@map("question_tag")
 }
 
 enum UserRole {


### PR DESCRIPTION
Summary
- Add QuestionVersion model and link Answer -> QuestionVersion (snapshotting).
- Add Answer fields: question_version_id (nullable), is_correct, time_taken_ms.
- Add Tag and QuestionTag tables.
- Add user flags: is_anonymized, deleted_at.
- Add timestamps (createdAt/updatedAt) to Subject/Topic.
- Minimal indexes will be added via migration. This PR contains only schema + migration files.

Important
- THIS PR contains only schema + migration files. No backfill scripts, no service logic, no tests.
- Backfill, service changes, and tests will be implemented in follow-up PR(s) (keeps review scope small).
- Run migrations on staging first and take DB snapshot before applying to production.

Checklist
- [ ] Migration folder committed (prisma/migrations/*)
- [ ] Schema file updated (prisma/schema.prisma)
- [ ] PR is schema-only (no app code changes)
- [ ] Staging migration & smoke tests planned before merging to main
